### PR TITLE
Pyhton38 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
       run: |
         python -m cibuildwheel --output-dir dist
       env:
-        # build just python 3.7
-        CIBW_BUILD: cp37-*
+        # build python 3.7 and 3.8
+        CIBW_BUILD: cp37-* cp38-
         # don't build i686 targets, can't seem to find cmake for these
         CIBW_SKIP: '*-manylinux_i686'
         # we need boost

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         python -m cibuildwheel --output-dir dist
       env:
         # build python 3.7 and 3.8
-        CIBW_BUILD: cp37-* cp38-
+        CIBW_BUILD: cp37-* cp38-*
         # don't build i686 targets, can't seem to find cmake for these
         CIBW_SKIP: '*-manylinux_i686'
         # we need boost


### PR DESCRIPTION
Add python 3.8 binary wheels for mac and linux - needed for chia-blockchain ci with upgraded install methods