### PR TITLE
fix undefined behavior in left-shifting negative numbers

### DIFF
--- a/src/Reducer.h
+++ b/src/Reducer.h
@@ -81,9 +81,9 @@ public:
         mpz_mul_si(ctx.fab, ctx.b, u * w);
         mpz_mul_si(ctx.fac, ctx.c, w * w);
 
-        mpz_mul_si(ctx.fba, ctx.a, u * v << 1);
+        mpz_mul_si(ctx.fba, ctx.a, uint_fast64_t(u * v) << 1);
         mpz_mul_si(ctx.fbb, ctx.b, u * x + v * w);
-        mpz_mul_si(ctx.fbc, ctx.c, w * x << 1);
+        mpz_mul_si(ctx.fbc, ctx.c, uint_fast64_t(w * x) << 1);
 
         mpz_mul_si(ctx.fca, ctx.a, v * v);
         mpz_mul_si(ctx.fcb, ctx.b, v * x);
@@ -206,7 +206,7 @@ bool bLZCHasHW=false;
       // a = c
       a = c;
       // b = -b + 2cs
-      b = -b + (c * s << 1);
+      b = -b + (uint_fast64_t(c * s) << 1);
       // c = a + cs^2 - bs
       c = a_ - s * (b_ - c * s);
 


### PR DESCRIPTION
this fixes issues highlighted by undefined-sanitizer:
```
Reducer.h:84:42: runtime error: left shift of negative value -1
Reducer.h:209:23: runtime error: left shift of negative value -218085997599378178
Reducer.h:86:42: runtime error: left shift of negative value -1
```

Someone that knows what's supposed to happen should look at this. I assume that the intention was to have the unsigned shifting behavior. I was a bit tempted to change thes `<< 1` to `* 2`, since that has the same semantics but with a wider contract (notably allows negative numbers). However, given that one of those numbers seems to have a lot of bits in it, using `*` might cause *overflow* instead.