### PR TITLE
fix out-of-bound accesses

### DIFF
--- a/src/integer_common.h
+++ b/src/integer_common.h
@@ -172,7 +172,7 @@ struct integer {
         res.resize(mpz_sizeinbase(impl, 2)/64 + 1, 0);
 
         size_t count;
-        mpz_export(&res[0], &count, -1, 8, 0, 0, impl);
+        mpz_export(res.data(), &count, -1, 8, 0, 0, impl);
         res.resize(count);
 
         return res;

--- a/src/proof_common.h
+++ b/src/proof_common.h
@@ -12,6 +12,7 @@ std::vector<unsigned char> ConvertIntegerToBytes(integer x, uint64_t num_bytes) 
     }
     for (int iter = 0; iter < num_bytes; iter++) {
         auto byte = (x % integer(256)).to_vector();
+        if (byte.empty()) byte.push_back(0);
         if (negative)
             byte[0] ^= 255;
         bytes.push_back(byte[0]);

--- a/src/provers.h
+++ b/src/provers.h
@@ -33,7 +33,7 @@ class Prover {
         mpz_mul_2exp(res.impl, res.impl, k);
         res = res / B;
         auto res_vector = res.to_vector();
-        return res_vector[0];
+        return res_vector.empty() ? 0 : res_vector[0];
     }
 
     void GenerateProof() {


### PR DESCRIPTION
there was a misunderstanding of `mpz_export()` causing 0 (which yields an empty vector) to trigger out-of-bounds accesses in code that assumed the vector had at least 1 element.