### PR TITLE
fix use of custom allocator for GMP

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -81,6 +81,21 @@ jobs:
         CIBW_TEST_COMMAND: py.test -v {project}/tests
         CIBW_ENVIRONMENT_LINUX: "BUILD_VDF_CLIENT=N"
 
+#    vdf_client hasn't been ported to ARM64 yet.
+#    - name: Build and test vdf-client
+#      run: |
+#        sudo apt-get install libgmp-dev libboost-python-dev libpython3-dev libboost-system-dev build-essential -y
+#        cd src
+#        make -f Makefile.vdf-client
+#        echo "Running 1weso_test"
+#        ./1weso_test
+#        echo "Running 2weso_test"
+#        ./2weso_test
+#        echo "Running prover_test"
+#        ./prover_test
+#        echo "Benchmarking vdf_client with 400,000 iterations of vdf_bench"
+#        ./vdf_bench square_asm 400000
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,9 +110,34 @@ jobs:
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: py.test -v {project}/tests
 
-    - name: build vdf-client
-      if: startsWith(matrix.os, 'mac') || matrix.os == 'Linux'
-      run: (cd src; make -f Makefile.vdf-client)
+    - name: Build and test vdf-client on Ubuntu
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get install libgmp-dev libboost-python-dev libpython3.7-dev libboost-system-dev build-essential -y
+        cd src
+        make -f Makefile.vdf-client
+        echo "Running 1weso_test"
+        ./1weso_test
+        echo "Running 2weso_test"
+        ./2weso_test
+        echo "Running prover_test"
+        ./prover_test
+        echo "Benchmarking vdf_client with 400,000 iterations of vdf_bench"
+        ./vdf_bench square_asm 400000
+
+    - name: Build and test vdf-client on MacOS
+      if: startsWith(matrix.os, 'mac')
+      run: |
+        cd src
+        make -f Makefile.vdf-client
+        echo "Running 1weso_test"
+        ./1weso_test
+        echo "Running 2weso_test"
+        ./2weso_test
+        echo "Running prover_test"
+        ./prover_test
+        echo "Benchmarking vdf_client with 400,000 iterations of vdf_bench"
+        ./vdf_bench square_asm 400000
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ src/compile_asm
 src/vdf_bench
 /vdf_server
 src/vdf_client
+src/1weso_test
+src/2weso_test
+src/prover_test
 /verifier
 /verifier_test
 /build/*

--- a/src/1weso_test.cpp
+++ b/src/1weso_test.cpp
@@ -15,6 +15,8 @@ int gcd_base_bits=50;
 int gcd_128_max_iter=3;
 
 int main() {
+    assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
+    init_gmp();
     debug_mode = true;
     if(hasAVX2())
     {
@@ -27,9 +29,6 @@ int main() {
     if (getenv( "warn_on_corruption_in_production" )!=nullptr) {
         warn_on_corruption_in_production=true;
     }
-    assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
-    init_gmp();
-    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
     set_rounding_mode();
 
     integer L=root(-D, 4);

--- a/src/2weso_test.cpp
+++ b/src/2weso_test.cpp
@@ -23,6 +23,8 @@ void CheckProof(integer& D, Proof& proof, uint64_t iteration) {
 }
 
 int main() {
+    assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
+    init_gmp();
     debug_mode = true;
     if(hasAVX2())
     {
@@ -35,9 +37,6 @@ int main() {
     if (getenv( "warn_on_corruption_in_production" )!=nullptr) {
         warn_on_corruption_in_production=true;
     }
-    assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
-    init_gmp();
-    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
     set_rounding_mode();
 
     integer L=root(-D, 4);

--- a/src/alloc.hpp
+++ b/src/alloc.hpp
@@ -1,0 +1,46 @@
+#ifndef ALLOC_H
+#define ALLOC_H
+
+#include <stdlib.h> // for posix_memalign
+
+inline void* mp_alloc_func(size_t new_bytes)
+{
+    new_bytes = ((new_bytes + 8) + 15) & ~15;
+#if defined _MSC_VER
+    uint8_t* ret = static_cast<uint8_t*>(_aligned_malloc(new_bytes, 16));
+#else
+    void* ptr = nullptr;
+    if (::posix_memalign(&ptr, 16, new_bytes) != 0) return nullptr;
+    uint8_t* ret = static_cast<uint8_t*>(ptr);
+#endif
+    return ret + 8;
+}
+
+inline void mp_free_func(void* old_ptr, size_t) {
+    // if the old_ptr alignment is not to 16 bytes + 8 bytes offset, we did not
+    // allocate it. It's an in-place buffer and should not be freed
+    if ((std::uintptr_t(old_ptr) & 15) != 8) return;
+
+#if defined _MSC_VER
+    _aligned_free(static_cast<uint8_t*>(old_ptr) - 8);
+#else
+    std::free(static_cast<uint8_t*>(old_ptr) - 8);
+#endif
+}
+
+inline void* mp_realloc_func(void* old_ptr, size_t old_size, size_t new_bytes) {
+
+    void* ret = mp_alloc_func(new_bytes);
+    ::memcpy(ret, old_ptr, std::min(old_size, new_bytes));
+    mp_free_func(old_ptr, old_size);
+    return ret;
+}
+
+//must call this before calling any gmp functions
+//(the mpz class constructor does not call any gmp functions)
+inline void init_gmp() {
+    mp_set_memory_functions(mp_alloc_func, mp_realloc_func, mp_free_func);
+    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
+}
+
+#endif

--- a/src/avx512_test.cpp
+++ b/src/avx512_test.cpp
@@ -78,7 +78,6 @@ template<class intnx, class avx512_intnx, class intjx, class avx512_intjx> void 
 int main(int argc, char **argv) {
     assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
     init_gmp();
-    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
     set_rounding_mode();
 
     enable_avx512_ifma=false;

--- a/src/prover_test.cpp
+++ b/src/prover_test.cpp
@@ -28,6 +28,8 @@ int gcd_base_bits=50;
 int gcd_128_max_iter=3;
 
 int main() {
+    assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
+    init_gmp();
     if(hasAVX2())
     {
       gcd_base_bits=63;
@@ -39,9 +41,6 @@ int main() {
     if (getenv( "warn_on_corruption_in_production" )!=nullptr) {
         warn_on_corruption_in_production=true;
     }
-    assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
-    init_gmp();
-    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
     set_rounding_mode();
 
     integer L=root(-D, 4);

--- a/src/python_bindings/fastvdf.cpp
+++ b/src/python_bindings/fastvdf.cpp
@@ -1,8 +1,15 @@
 #include <pybind11/pybind11.h>
 #include "../verifier.h"
 #include "../prover_slow.h"
+#include "../alloc.hpp"
 
 namespace py = pybind11;
+
+namespace {
+struct init {
+    init() { init_gmp(); }
+} g_init;
+}
 
 PYBIND11_MODULE(chiavdf, m) {
     m.doc() = "Chia proof of time";

--- a/src/threading.h
+++ b/src/threading.h
@@ -1,7 +1,7 @@
 #ifndef THREADING_H
 #define THREADING_H
 
-#include <boost/align/aligned_alloc.hpp>
+#include "alloc.hpp"
 
 //mp_limb_t is an unsigned integer
 static_assert(sizeof(mp_limb_t)==8, "");
@@ -155,61 +155,6 @@ static uint64 get_time_cycles() {
     #define TRACK_CYCLES_ABORT
     #define TRACK_CYCLES_OUTPUT_STATS
 #endif
-
-//use realloc or free to free the memory
-void* alloc_cache_line(size_t bytes) {
-    //round up to the next multiple of 64
-    size_t aligned_bytes=((bytes+63)>>6)<<6;
-
-    //padding so that the result
-    aligned_bytes+=64;
-
-    void* res=boost::alignment::aligned_alloc(64, aligned_bytes); // aligned_alloc(64, aligned_bytes);
-
-    //the address modulo 64 is used to decide if the gmp integer is allocated on the stack or the heap
-    //stack integers are 64-aligned and heap integers aren't
-    res=((char*)res)+16;
-
-    assert((uint64(res)&63)==16); //must have this alignment for correctness
-    return res;
-}
-
-void free_cache_line(void* ptr) {
-    boost::alignment::aligned_free(((char*)ptr)-16); //free(old_ptr);
-}
-
-void* mp_alloc_func(size_t new_bytes) {
-    return alloc_cache_line(new_bytes);
-}
-
-void mp_free_func(void* old_ptr, size_t old_bytes) {
-    //either mp_alloc_func allocated old_ptr and it is 64-aligned, or it points to data in mpz and its address equals 16 modulo 64
-    assert((uint64(old_ptr)&63)==0 || (uint64(old_ptr)&63)==16);
-
-    if ((uint64(old_ptr)&63)==16) {
-        //mp_alloc_func allocated this, so it can be freed with std::free
-        free_cache_line(old_ptr);
-    } else {
-        //this is part of the mpz struct defined below. it can't be freed, so do nothing
-    }
-}
-
-void* mp_realloc_func(void* old_ptr, size_t old_bytes, size_t new_bytes) {
-    void* res=mp_alloc_func(new_bytes);
-
-    memcpy(res, old_ptr, (old_bytes<new_bytes)? old_bytes : new_bytes);
-
-    mp_free_func(old_ptr, old_bytes);
-
-    return res;
-}
-
-//must call this before calling any gmp functions
-//(the mpz class constructor does not call any gmp functions)
-void init_gmp() {
-    mp_set_memory_functions(mp_alloc_func, mp_realloc_func, mp_free_func);
-    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
-}
 
 template<int d_expected_size, int d_padded_size> struct alignas(64) mpz;
 
@@ -591,35 +536,6 @@ template<int d_expected_size, int d_padded_size> struct alignas(64) mpz {
         return res;
     }
 };
-
-template<class type> struct cache_line_ptr {
-    type* ptr=nullptr;
-
-    cache_line_ptr() {}
-    cache_line_ptr(cache_line_ptr& t)=delete;
-    cache_line_ptr(cache_line_ptr&& t) { swap(ptr, t.ptr); }
-
-    cache_line_ptr& operator=(cache_line_ptr& t)=delete;
-    cache_line_ptr& operator=(cache_line_ptr&& t) { swap(ptr, t.ptr); }
-
-    ~cache_line_ptr() {
-        if (ptr) {
-            ptr->~type();
-            boost::alignment::aligned_free(ptr); // wjb free(ptr);
-            ptr=nullptr;
-        }
-    }
-
-    type& operator*() const { return *ptr; }
-    type* operator->() const { return ptr; }
-};
-
-template<class type, class... arg_types> cache_line_ptr<type> make_cache_line(arg_types&&... args) {
-    cache_line_ptr<type> res;
-    res.ptr=(type*)alloc_cache_line(sizeof(type));
-    new(res.ptr) type(forward<arg_types>(args)...);
-    return res;
-}
 
 template<bool is_write, class type> void prefetch(const type& p) {
     //write prefetching lowers performance but read prefetching increases it

--- a/src/threading.h
+++ b/src/threading.h
@@ -208,6 +208,7 @@ void* mp_realloc_func(void* old_ptr, size_t old_bytes, size_t new_bytes) {
 //(the mpz class constructor does not call any gmp functions)
 void init_gmp() {
     mp_set_memory_functions(mp_alloc_func, mp_realloc_func, mp_free_func);
+    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
 }
 
 template<int d_expected_size, int d_padded_size> struct alignas(64) mpz;

--- a/src/vdf_bench.cpp
+++ b/src/vdf_bench.cpp
@@ -27,7 +27,6 @@ int main(int argc, char **argv)
 {
     assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
     init_gmp();
-    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
     set_rounding_mode();
 
     if (argc < 3) {

--- a/src/vdf_client.cpp
+++ b/src/vdf_client.cpp
@@ -126,7 +126,6 @@ void InitSession(tcp::socket& sock) {
     }
     assert(is_vdf_test); //assertions should be disabled in VDF_MODE==0
     init_gmp();
-    allow_integer_constructor=true; //make sure the old gmp allocator isn't used
     set_rounding_mode();
 }
 


### PR DESCRIPTION
the way things work right now, `init_gmp()` has to be called very early, before any `integer` object is created (really, before any GMP integer is initialized).

The consequence of not doing this is that an integer may be allocated by the default allocator, and freed by our custom allocator. i.e. memory corruption.