### PR TITLE
Use only Baillie-PSW primality test when hashing to prime

### DIFF
--- a/src/integer_common.h
+++ b/src/integer_common.h
@@ -331,7 +331,9 @@ struct integer {
     }
 
     bool prime() const {
-        return mpz_probab_prime_p(impl, 50)!=0;
+        // reps=24 makes GMP 6.2.1 do only the Baillie-PSW primality test
+        // without additional Miller-Rabin rounds.
+        return mpz_probab_prime_p(impl, 24) != 0;
     }
 
     bool operator<(const integer& t) const {


### PR DESCRIPTION
This increases performance of hashing to prime when generating the
discriminant by about 2x.