### PR TITLE
Require size of serialized compressed forms to be 100 bytes

### DIFF
--- a/src/bqfc.h
+++ b/src/bqfc.h
@@ -15,6 +15,9 @@ struct qfb_c {
     bool b_sign;
 };
 
+#define BQFC_MAX_D_BITS 1024
+/* Force all forms to have the same size (100 bytes). */
+#define BQFC_FORM_SIZE ((BQFC_MAX_D_BITS + 31) / 32 * 3 + 4)
 
 int bqfc_compr(struct qfb_c *out_c, mpz_t a, mpz_t b);
 

--- a/src/proof_common.h
+++ b/src/proof_common.h
@@ -60,8 +60,7 @@ integer HashPrime(std::vector<uint8_t> seed, int length, vector<int> bitmask) {
 std::vector<unsigned char> SerializeForm(form &y, int d_bits)
 {
     y.reduce();
-    int form_size = bqfc_get_compr_size(d_bits);
-    std::vector<unsigned char> res(form_size);
+    std::vector<unsigned char> res(BQFC_FORM_SIZE);
     bqfc_serialize(res.data(), y.a.impl, y.b.impl, d_bits);
     return res;
 }

--- a/src/vdf_client.cpp
+++ b/src/vdf_client.cpp
@@ -78,7 +78,7 @@ void CreateAndWriteProofTwoWeso(integer& D, form f, uint64_t iters, TwoWesolowsk
     WriteProof(iters, result, sock);
 }
 
-char initial_form_s[100];
+char initial_form_s[BQFC_FORM_SIZE];
 
 void InitSession(tcp::socket& sock) {
     boost::system::error_code error;

--- a/src/verifier.h
+++ b/src/verifier.h
@@ -53,7 +53,7 @@ integer ConvertBytesToInt(const uint8_t* bytes, int32_t start_index, int32_t end
 
 bool CheckProofOfTimeNWesolowski(integer D, const uint8_t* x_s, const uint8_t* proof_blob, int32_t proof_blob_len, uint64_t iterations, uint64 disc_size_bits, int32_t depth)
 {
-    int form_size = bqfc_get_compr_size(D.num_bits());
+    int form_size = BQFC_FORM_SIZE;
     form x = DeserializeForm(D, x_s, form_size);
 
     if (proof_blob_len != 2 * form_size + depth * (8 + 2 * form_size))

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7,8 +7,8 @@ def test_prove_and_verify():
     discriminant_challenge = secrets.token_bytes(10)
     discriminant_size = 512
     discriminant = create_discriminant(discriminant_challenge, discriminant_size)
-    form_size = discriminant_size // 32 * 3 + 4
-    initial_el = bytes([0x08])
+    form_size = 100
+    initial_el = b"\x08" + (b"\x00" * 99)
 
     iters = 1000000
     t1 = time.time()


### PR DESCRIPTION
The size is the same regardless of discriminant bits or a form being
'special' (identity or generator). This allows using a fixed-size object
(bytes100) for quadratic forms in chia-blockchain.