### PR TITLE
use swap{16,32,64} from <endian.h> on OpenBSD

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -19,13 +19,16 @@
 #define bswap_64(x) OSSwapInt64(x)
 #elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 # if defined(__OpenBSD__)
-#  include <machine/endian.h>
+#  include <endian.h>
+#  define bswap_16(x) swap16(x)
+#  define bswap_32(x) swap32(x)
+#  define bswap_64(x) swap64(x)
 # else
 #  include <sys/endian.h>
+#  define bswap_16(x) bswap16(x)
+#  define bswap_32(x) bswap32(x)
+#  define bswap_64(x) bswap64(x)
 # endif
-#define bswap_16(x) bswap16(x)
-#define bswap_32(x) bswap32(x)
-#define bswap_64(x) bswap64(x)
 #else
 #include <byteswap.h>
 #endif


### PR DESCRIPTION
This fixes a compile issue on OpenBSD, because bswap is not supported. Tested on OpenBSD 6.8 stable.

Furthermore, the man pages of [NetBSD](http://man.netbsd.org/bswap.3) and [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=bswap64&apropos=0&sektion=0&manpath=FreeBSD+12.2-RELEASE+and+Ports&arch=default&format=html) indicate these platforms do support bswap{16,32,64}.

Same as https://github.com/Chia-Network/chiapos/pull/183.