### PR TITLE
do not use lzcnt64_hard directly to allow compilation on ppc64le

### DIFF
--- a/src/Reducer.h
+++ b/src/Reducer.h
@@ -23,10 +23,22 @@ limitations under the License.
 
 #include "ClassGroup.h"
 
+#ifdef __has_attribute
+# define HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+# define HAS_ATTRIBUTE(x) 0
+#endif
+
+#if HAS_ATTRIBUTE(weak)
+# define WEAK __attribute__((weak))
+#else
+# define WEAK
+#endif
+
 extern "C" {
 int has_lzcnt_hard();
 unsigned int lzcnt64_soft(unsigned long long x);
-unsigned int lzcnt64_hard(unsigned long long x);
+unsigned int lzcnt64_hard(unsigned long long x) WEAK;
 }
 
 /** constants utilized in reduction algorithm */


### PR DESCRIPTION
lzcnt64 doesn't have lzcnt64_hard implementation resulting in no lzcnt64_hard symbol being created, failing at linking.

You should be using generic lzcnt64() symbol which gets implemented as hard or soft, depending on whether hard implementation is available.