### PR TITLE
Fix deadlock in vdf_client

### DIFF
--- a/src/vdf.h
+++ b/src/vdf.h
@@ -242,9 +242,11 @@ void repeated_square(form f, const integer& D, const integer& L,
 Proof ProveOneWesolowski(uint64_t iters, integer& D, form f, OneWesolowskiCallback* weso,
     std::atomic<bool>& stopped)
 {
-    while (weso->iterations < iters) {
+    while (!stopped && weso->iterations < iters) {
         this_thread::sleep_for(1s);
     }
+    if (stopped)
+        return Proof();
     Segment sg(
         /*start=*/0,
         /*length=*/iters,


### PR DESCRIPTION
Add missing logic to handle stopped signal in one-weso proofs.

For one-weso proofs, vdf_client launches two threads to do its work. One
repeatedly squares until a given number of iterations, the second waits
until the first is done squaring and then computes a proof.

The squaring-thread properly handles the "stopped" signal and aborts
early, if signaled. That way, it never reaches the targeted iterations.
The 1weso-thread waits until the target iterations are reached, but does
not handle the "stopped" signal. Thus, for stopped iters, it waits
infinitely.

This situation regularly occurs, vdf_client is running for a bluebox
timelord. Whenever the timelord (Python) process restarts, network
communication errors out, killing the squaring thread. But instead of
the while vdf_client exiting (which would lead to the timelord launcher
cleanly restarting a fresh one), the 1weso thread keeps the vdf_client
alive infinitely.

The fix itself is just as it's done for 2weso proofs and elsewhere. The
1weso caller already handles stopped correctly, so 1weso can just
return a default-constructed proof.