### PR TITLE
Fix CI builds for Apple M1

### DIFF
--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Ensure dependencies are present
       run: |
-        brew install gmp boost
+        arch -arm64 brew install gmp boost
 
     - name: Lint source with flake8
       run: |


### PR DESCRIPTION
This should get the M1 CI working again. Compare the homebrew error message in, for example, https://github.com/Chia-Network/chiavdf/runs/4492836462?check_suite_focus=true.