### PR TITLE
Fix primality test for very small numbers

### DIFF
--- a/src/pprods.h
+++ b/src/pprods.h
@@ -386,4 +386,6 @@ static const uint64_t pprods[] = {
     0xaf157a9999de1f,    // 14887*14891*14897*14923
     0xb1110edec9a5e7,    // 14929*14939*14947*14951
 };
+
+static const uint32_t pprods_max_prime = 14951;
 #endif // PPRODS_H

--- a/tools/gen_pprods.py
+++ b/tools/gen_pprods.py
@@ -73,6 +73,8 @@ def print_pprods_h(prods, factors):
 static const uint64_t pprods[] = {
 %s
 };
+
+static const uint32_t pprods_max_prime = %d;
 #endif // PPRODS_H
 """
     tmpl = tmpl.strip()
@@ -81,7 +83,7 @@ static const uint64_t pprods[] = {
         factors_str = "*".join(map(str, factors[i]))
         extra_spaces = " " * (16 - (pr.bit_length() + 3) // 4)
         prods_str += tab + "0x%x,  %s// %s\n" % (pr, extra_spaces, factors_str)
-    print(tmpl % (prods_str.rstrip(),))
+    print(tmpl % (prods_str.rstrip(), factors[-1][-1]))
 
 
 n = int(sys.argv[1])


### PR DESCRIPTION
Add special cases for primes 2, 3, 5 and 7. Proceed to Miller-Rabin and
BPSW primality tests to get the correct primality result for other small
primes that are factors in the prime products, which are used in the
initial phase of primality testing.

Previously small prime numbers up to 14951 were incorrectly reported as
composite. As this primality test has never been used for so small
numbers, there were no issues in its usage.