### PR TITLE
Correctly handle fallback_version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.5.0", "pybind11"
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+fallback_version = "unknown-no-.git-directory"
 local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -280,5 +280,4 @@ else:
             build_ext=CMakeBuild, install_hook=install_hook, build_hook=build_hook
         ),
         zip_safe=False,
-        use_scm_version={"fallback_version": "unknown-no-.git-directory"},
     )

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,6 @@ if platform.system() == "Windows":
         ext_modules=ext_modules,
         cmdclass={"build_ext": BuildExt},
         zip_safe=False,
-        use_scm_version={"fallback_version": "unknown-no-.git-directory"},
     )
 else:
     build.sub_commands.append(("build_hook", lambda x: True))  # type: ignore


### PR DESCRIPTION
This will stop testpypi uploads from failing in CI