### PR TITLE
Use setuptools.command.build.build instead of deprecated distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ import re
 import shutil
 import subprocess
 import sys
-from distutils.command.build import build  # type: ignore
 from distutils.command.install import install
 from distutils.version import LooseVersion
 
 from setuptools import Command, Extension, setup, setuptools
+from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
 
 BUILD_HOOKS = []


### PR DESCRIPTION
```
        /private/var/folders/k6/yt391w5n017djpb0378ncm3c0000gn/T/pip-build-env-n4anwt9p/overlay/lib/python3.11/site-packages/setuptools/command/build.py:22: SetuptoolsDeprecationWarning:
                    It seems that you are using `distutils.command.build` to add
                    new subcommands. Using `distutils` directly is considered deprecated,
                    please use `setuptools.command.build`.
```