### PR TITLE
Fix error message on invalid number of args for `vdf_client`.

### DIFF
--- a/src/vdf_client.cpp
+++ b/src/vdf_client.cpp
@@ -316,7 +316,7 @@ int main(int argc, char* argv[]) try
     init_gmp();
     if (argc != 4)
     {
-      std::cerr << "Usage: ./vdf_client <host> <port>\n";
+      std::cerr << "Usage: ./vdf_client <host> <port> <counter>\n";
       return 1;
     }
 


### PR DESCRIPTION
The user will not be able to start vdf_client when the error message is incorrect.