### PR TITLE
use libpython3-dev instead of libpython3.8-dev

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Build vdf-client on Ubuntu
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        sudo apt-get install libgmp-dev libboost-python-dev libpython3.8-dev libboost-system-dev build-essential -y
+        sudo apt-get install libgmp-dev libboost-python-dev libpython3-dev libboost-system-dev build-essential -y
         cd src
         make ${{ matrix.config }} -f Makefile.vdf-client
 


### PR DESCRIPTION
https://github.com/Chia-Network/chiavdf/actions/runs/3888384319/jobs/6635642471#step:3:16
```
E: Package 'libpython3.8-dev' has no installation candidate
```

I suspect that this broke with the transition of `ubuntu-latest` runners from Ubuntu 20.04 to 22.04.  Unless we need 3.8 specifically then let's just take whatever the Ubuntu is giving us, or explicitly matrix across 'all' versions.

Draft for:
- [x] asking around for reasons we might need to be testing with 3.8 specifically