### PR TITLE
Switch to macos-11 for building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
             matrix: macos
             runs-on:
               arm: [macOS, ARM64]
-              intel: [macos-latest]
+              intel: [macos-11]
             cibw-archs-macos:
               arm: arm64
               intel: x86_64
@@ -94,7 +94,7 @@ jobs:
               matrix: macos
               runs-on:
                 arm: [macOS, ARM64]
-                intel: [macos-latest]
+                intel: [macos-11]
             python:
               major-dot-minor: '3.7'
               cibw-build: 'cp37-*'


### PR DESCRIPTION
Use `macos-11` instead of `macos-latest` for proper GMP artifacts to include in the wheel

This creates a wheel that does work currently on macOS 10.14+ as it includes a version of the GMP library that runs on those platforms.

The version of GMP included when using `macos-latest` does not run on macOS 10.14