### PR TITLE
Move cibw config to pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,56 +122,10 @@ jobs:
 
     - name: Build and test
       env:
-        CIBW_BUILD_VERBOSITY_MACOS: 0
-        CIBW_BUILD_VERBOSITY_LINUX: 0
-        CIBW_BUILD_VERBOSITY_WINDOWS: 0
         CIBW_BUILD: ${{ matrix.python.cibw-build }}
-        CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.python.manylinux['intel'] }}
-        CIBW_ENVIRONMENT_LINUX: "PATH=/project/cmake-3.17.3-Linux-`uname -m`/bin:$PATH BUILD_VDF_CLIENT=N"
-        CIBW_BEFORE_ALL_LINUX: >
-          yum -y install epel-release
-          && echo "epel-release installed"
-          && yum -y install boost-devel lzip
-          && echo "boost-devel and lzip installed"
-          && curl -L https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-`uname -m`.sh > cmake.sh
-          && yes | sh cmake.sh | cat
-          && rm -f /usr/bin/cmake
-          && curl -L https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz | tar x --lzip
-          && cp src/lib/gmp-patch-6.2.1/longlong.h gmp-6.2.1/
-          && cp src/lib/gmp-patch-6.2.1/compat.c gmp-6.2.1/
-          && cp src/lib/gmp-patch-6.2.1/mpz/inp_raw.c gmp-6.2.1/mpz
-          && cd gmp-6.2.1 && ./configure --enable-fat --enable-cxx
-          && make && make install && cd .. && rm -rf gmp-6.2.1
-          && cmake --version
-          && uname -a
-        CIBW_BEFORE_BUILD_LINUX: >
-          python -m pip install --upgrade pip
         CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
-        CIBW_BEFORE_ALL_MACOS: >
-          brew install gmp boost cmake
-        CIBW_BEFORE_BUILD_MACOS: >
-          python -m pip install --upgrade pip
-        CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.14 BUILD_VDF_CLIENT=N"
-        CIBW_BEFORE_ALL_WINDOWS: >
-          git clone https://github.com/Chia-Network/mpir_gc_x64.git
-        CIBW_ENVIRONMENT_WINDOWS: "BUILD_VDF_CLIENT=N SETUPTOOLS_USE_DISTUTILS=stdlib"
-        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
-          ls -l mpir_gc_x64 && pip uninstall -y delocate
-          && pip install git+https://github.com/Chia-Network/delocate.git
-          && delocate-wheel -v -i mpir_gc_x64/mpir.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_gc.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_broadwell.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_broadwell_avx.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_bulldozer.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_haswell.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_piledriver.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_sandybridge.dll {wheel}
-          && delocate-wheel -v -i mpir_gc_x64/mpir_skylake_avx.dll {wheel}
-          && cp {wheel} {dest_dir}
-        CIBW_TEST_REQUIRES: pytest
-        CIBW_TEST_COMMAND: py.test -v {project}/tests
         CIBW_PRERELEASE_PYTHONS: True
       run:
         pipx run --spec='cibuildwheel==2.11.1' cibuildwheel --output-dir dist 2>&1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ skip = "*-manylinux_i686 *-win32 *-musllinux_*"
 [tool.cibuildwheel.linux]
 build-verbosity = 0
 before-all = """
+yum -y install epel-release \
+&& echo "epel-release installed" \
+&& yum -y install boost-devel lzip \
+&& echo "boost-devel and lzip installed" \
 curl -L https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz | tar x --lzip \
 && cp src/lib/gmp-patch-6.2.1/longlong.h gmp-6.2.1/ \
 && cp src/lib/gmp-patch-6.2.1/compat.c gmp-6.2.1/ \
@@ -21,7 +25,7 @@ curl -L https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz | tar x --lzip \
 && cd gmp-6.2.1 && ./configure --enable-fat --enable-cxx \
 && make && make install && cd .. && rm -rf gmp-6.2.1 \
 && cmake --version \
-&& uname -a
+&& uname -a \
 """
 before-build = "python -m pip install --upgrade pip"
 
@@ -47,5 +51,5 @@ ls -l mpir_gc_x64 && pip uninstall -y delocate \
 && delocate-wheel -v -i mpir_gc_x64/mpir_piledriver.dll {wheel} \
 && delocate-wheel -v -i mpir_gc_x64/mpir_sandybridge.dll {wheel} \
 && delocate-wheel -v -i mpir_gc_x64/mpir_skylake_avx.dll {wheel} \
-&& cp {wheel} {dest_dir}
+&& cp {wheel} {dest_dir} \
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ test-command = "pytest -v {project}/tests"
 skip = "*-manylinux_i686 *-win32 *-musllinux_*"
 
 [tool.cibuildwheel.linux]
+environment = "BUILD_VDF_CLIENT=N"
 build-verbosity = 0
 before-all = """
 yum -y install epel-release \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ yum -y install epel-release \
 && echo "epel-release installed" \
 && yum -y install boost-devel lzip \
 && echo "boost-devel and lzip installed" \
-curl -L https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz | tar x --lzip \
+&& curl -L https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz | tar x --lzip \
 && cp src/lib/gmp-patch-6.2.1/longlong.h gmp-6.2.1/ \
 && cp src/lib/gmp-patch-6.2.1/compat.c gmp-6.2.1/ \
 && cp src/lib/gmp-patch-6.2.1/mpz/inp_raw.c gmp-6.2.1/mpz \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,47 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 fallback_version = "unknown-no-.git-directory"
 local_scheme = "no-local-version"
+
+[tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "pytest -v {project}/tests"
+skip = "*-manylinux_i686 *-win32 *-musllinux_*"
+
+[tool.cibuildwheel.linux]
+build-verbosity = 0
+before-all = """
+curl -L https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz | tar x --lzip \
+&& cp src/lib/gmp-patch-6.2.1/longlong.h gmp-6.2.1/ \
+&& cp src/lib/gmp-patch-6.2.1/compat.c gmp-6.2.1/ \
+&& cp src/lib/gmp-patch-6.2.1/mpz/inp_raw.c gmp-6.2.1/mpz \
+&& cd gmp-6.2.1 && ./configure --enable-fat --enable-cxx \
+&& make && make install && cd .. && rm -rf gmp-6.2.1 \
+&& cmake --version \
+&& uname -a
+"""
+before-build = "python -m pip install --upgrade pip"
+
+[tool.cibuildwheel.macos]
+build-verbosity = 0
+before-all = "brew install gmp boost cmake"
+before-build = "python -m pip install --upgrade pip"
+environment = {MACOSX_DEPLOYMENT_TARGET="11", SYSTEM_VERSION_COMPAT=0, BUILD_VDF_CLIENT="N"}
+
+[tool.cibuildwheel.windows]
+build-verbosity = 0
+before-all = "git clone https://github.com/Chia-Network/mpir_gc_x64.git"
+environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
+repair-wheel-command = """
+ls -l mpir_gc_x64 && pip uninstall -y delocate \
+&& pip install git+https://github.com/Chia-Network/delocate.git \
+&& delocate-wheel -v -i mpir_gc_x64/mpir.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_gc.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_broadwell.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_broadwell_avx.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_bulldozer.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_haswell.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_piledriver.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_sandybridge.dll {wheel} \
+&& delocate-wheel -v -i mpir_gc_x64/mpir_skylake_avx.dll {wheel} \
+&& cp {wheel} {dest_dir}
+"""


### PR DESCRIPTION
Puts most `cibuildwheel` configuration into `pyproject.toml` instead of using envvars in the github actions.

The rationale is that this makes it a little bit easier to build the wheel locally for debugging and testing as there is less configuration specific to GH actions

Note some of the envvars refer to GH action matrix items, so those remain in the GH workflow.