### PR TITLE
Update to pybind v2.11.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11-src
   GIT_REPOSITORY https://github.com/pybind/pybind11.git
-  GIT_TAG        v2.10.0
+  GIT_TAG        v2.11.1
 )
 FetchContent_MakeAvailable(pybind11-src)
 


### PR DESCRIPTION
Cmake is deprecating the way pybind finds the python interpreter. See https://cmake.org/cmake/help/latest/policy/CMP0148.html and pybind/pybind11#4719