### PR TITLE
Add python 3.12

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -40,6 +40,9 @@ jobs:
             matrix: '3.10'
           - major-dot-minor: '3.11'
             matrix: '3.11'
+          - major-dot-minor: '3.12'
+            matrix: '3.12'
+
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -40,9 +40,6 @@ jobs:
             matrix: '3.10'
           - major-dot-minor: '3.11'
             matrix: '3.11'
-          - major-dot-minor: '3.12'
-            matrix: '3.12'
-
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
         CIBW_PRERELEASE_PYTHONS: True
       run:
-        pipx run --spec='cibuildwheel==2.11.2' cibuildwheel --output-dir dist 2>&1
+        pipx run --spec='cibuildwheel==2.16.2' cibuildwheel --output-dir dist 2>&1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,13 @@ jobs:
               arch: manylinux2014
               intel: manylinux2014
             matrix: '3.11'
+          - major-dot-minor: '3.12'
+            cibw-build: 'cp312-*'
+            manylinux:
+              arch: manylinux2014
+              intel: manylinux2014
+            matrix: '3.12'
+
         arch:
           - name: ARM
             matrix: arm
@@ -84,19 +91,6 @@ jobs:
               matrix: windows
               runs-on:
                 intel: [windows-latest]
-            arch:
-              name: ARM
-              matrix: arm
-          - os:
-              name: macOS
-              matrix: macos
-              runs-on:
-                arm: [macOS, ARM64]
-                intel: [macos-11]
-            python:
-              major-dot-minor: '3.7'
-              cibw-build: 'cp37-*'
-              matrix: '3.7'
             arch:
               name: ARM
               matrix: arm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,6 @@ environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
 before-build = "pip install delvewheel"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \
---add-path mpir_gc_x64
+--add-path mpir_gc_x64 \
 --add-dll mpir.dll;mpir_gc.dll;mpir_broadwell.dll;mpir_broadwell_avx.dll;mpir_bulldozer.dll;mpir_haswell.dll;mpir_piledriver.dll;mpir_sandybridge.dll;mpir_skylake_avx.dll \
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,17 +40,16 @@ environment = {MACOSX_DEPLOYMENT_TARGET="11", SYSTEM_VERSION_COMPAT=0, BUILD_VDF
 build-verbosity = 0
 before-all = "git clone https://github.com/Chia-Network/mpir_gc_x64.git"
 environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
+before-build = "pip install delvewheel"
 repair-wheel-command = """
-ls -l mpir_gc_x64 && pip uninstall -y delocate \
-&& pip install git+https://github.com/Chia-Network/delocate.git \
-&& delocate-wheel -v -i mpir_gc_x64/mpir.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_gc.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_broadwell.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_broadwell_avx.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_bulldozer.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_haswell.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_piledriver.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_sandybridge.dll {wheel} \
-&& delocate-wheel -v -i mpir_gc_x64/mpir_skylake_avx.dll {wheel} \
-&& cp {wheel} {dest_dir} \
+delvewheel repair -v -w {dest_dir} {wheel} \
+--add-dll mpir_gc_x64/mpir.dll;\
+mpir_gc_x64/mpir_gc.dll;\
+mpir_gc_x64/mpir_broadwell.dll;\
+mpir_gc_x64/mpir_broadwell_avx.dll;\
+mpir_gc_x64/mpir_bulldozer.dll;\
+mpir_gc_x64/mpir_haswell.dll;\
+mpir_gc_x64/mpir_piledriver.dll;\
+mpir_gc_x64/mpir_sandybridge.dll;\
+mpir_gc_x64/mpir_skylake_avx.dll \
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
 before-build = "pip install delvewheel"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \
---add-dll mpir_gc_x64/mpir.dll;\
-mpir_gc_x64/mpir_gc.dll;\
-mpir_gc_x64/mpir_broadwell.dll;\
-mpir_gc_x64/mpir_broadwell_avx.dll;\
-mpir_gc_x64/mpir_bulldozer.dll;\
-mpir_gc_x64/mpir_haswell.dll;\
-mpir_gc_x64/mpir_piledriver.dll;\
-mpir_gc_x64/mpir_sandybridge.dll;\
-mpir_gc_x64/mpir_skylake_avx.dll \
+--add-dll .\\mpir_gc_x64\\mpir.dll;\
+.\\mpir_gc_x64\\mpir_gc.dll;\
+.\\mpir_gc_x64\\mpir_broadwell.dll;\
+.\\mpir_gc_x64\\mpir_broadwell_avx.dll;\
+.\\mpir_gc_x64\\mpir_bulldozer.dll;\
+.\\mpir_gc_x64\\mpir_haswell.dll;\
+.\\mpir_gc_x64\\mpir_piledriver.dll;\
+.\\mpir_gc_x64\\mpir_sandybridge.dll;\
+.\\mpir_gc_x64\\mpir_skylake_avx.dll \
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.5.0", "pybind11>=2.10.0"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.5.0", "pybind11>=2.10.0", "looseversion"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -28,19 +28,19 @@ yum -y install epel-release \
 && cmake --version \
 && uname -a \
 """
-before-build = "python -m pip install --upgrade pip && pip install looseversion"
+before-build = "python -m pip install --upgrade pip"
 
 [tool.cibuildwheel.macos]
 build-verbosity = 0
 before-all = "brew install gmp boost cmake"
-before-build = "python -m pip install --upgrade pip && pip install looseversion"
+before-build = "python -m pip install --upgrade pip"
 environment = {MACOSX_DEPLOYMENT_TARGET="11", SYSTEM_VERSION_COMPAT=0, BUILD_VDF_CLIENT="N"}
 
 [tool.cibuildwheel.windows]
 build-verbosity = 0
 before-all = "git clone https://github.com/Chia-Network/mpir_gc_x64.git"
 environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
-before-build = "pip install delvewheel && pip install looseversion"
+before-build = "pip install delvewheel"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \
 --add-path mpir_gc_x64 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
 before-build = "pip install delvewheel"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \
---add-dll mpir_gc_x64\mpir.dll;\
-mpir_gc_x64\mpir_gc.dll;\
-mpir_gc_x64\mpir_broadwell.dll;\
-mpir_gc_x64\mpir_broadwell_avx.dll;\
-mpir_gc_x64\mpir_bulldozer.dll;\
-mpir_gc_x64\mpir_haswell.dll;\
-mpir_gc_x64\mpir_piledriver.dll;\
-mpir_gc_x64\mpir_sandybridge.dll;\
-mpir_gc_x64\mpir_skylake_avx.dll \
+--add-dll mpir_gc_x64/mpir.dll;\
+mpir_gc_x64/mpir_gc.dll;\
+mpir_gc_x64/mpir_broadwell.dll;\
+mpir_gc_x64/mpir_broadwell_avx.dll;\
+mpir_gc_x64/mpir_bulldozer.dll;\
+mpir_gc_x64/mpir_haswell.dll;\
+mpir_gc_x64/mpir_piledriver.dll;\
+mpir_gc_x64/mpir_sandybridge.dll;\
+mpir_gc_x64/mpir_skylake_avx.dll \
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,6 @@ environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
 before-build = "pip install delvewheel"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \
---add-dll .\\mpir_gc_x64\\mpir.dll;\
-.\\mpir_gc_x64\\mpir_gc.dll;\
-.\\mpir_gc_x64\\mpir_broadwell.dll;\
-.\\mpir_gc_x64\\mpir_broadwell_avx.dll;\
-.\\mpir_gc_x64\\mpir_bulldozer.dll;\
-.\\mpir_gc_x64\\mpir_haswell.dll;\
-.\\mpir_gc_x64\\mpir_piledriver.dll;\
-.\\mpir_gc_x64\\mpir_sandybridge.dll;\
-.\\mpir_gc_x64\\mpir_skylake_avx.dll \
+--add-path mpir_gc_x64
+--add-dll mpir.dll;mpir_gc.dll;mpir_broadwell.dll;mpir_broadwell_avx.dll;mpir_bulldozer.dll;mpir_haswell.dll;mpir_piledriver.dll;mpir_sandybridge.dll;mpir_skylake_avx.dll \
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,19 +28,19 @@ yum -y install epel-release \
 && cmake --version \
 && uname -a \
 """
-before-build = "python -m pip install --upgrade pip"
+before-build = "python -m pip install --upgrade pip && pip install looseversion"
 
 [tool.cibuildwheel.macos]
 build-verbosity = 0
 before-all = "brew install gmp boost cmake"
-before-build = "python -m pip install --upgrade pip"
+before-build = "python -m pip install --upgrade pip && pip install looseversion"
 environment = {MACOSX_DEPLOYMENT_TARGET="11", SYSTEM_VERSION_COMPAT=0, BUILD_VDF_CLIENT="N"}
 
 [tool.cibuildwheel.windows]
 build-verbosity = 0
 before-all = "git clone https://github.com/Chia-Network/mpir_gc_x64.git"
 environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
-before-build = "pip install delvewheel"
+before-build = "pip install delvewheel && pip install looseversion"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \
 --add-path mpir_gc_x64 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ environment = {MACOSX_DEPLOYMENT_TARGET="11", SYSTEM_VERSION_COMPAT=0, BUILD_VDF
 [tool.cibuildwheel.windows]
 build-verbosity = 0
 before-all = "git clone https://github.com/Chia-Network/mpir_gc_x64.git"
-environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
+environment = {BUILD_VDF_CLIENT="N"}
 before-build = "pip install delvewheel"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.5.0", "pybind11>=2.10.0", "looseversion"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.5.0", "pybind11>=2.10.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ environment = {BUILD_VDF_CLIENT="N", SETUPTOOLS_USE_DISTUTILS="stdlib"}
 before-build = "pip install delvewheel"
 repair-wheel-command = """
 delvewheel repair -v -w {dest_dir} {wheel} \
---add-dll mpir_gc_x64/mpir.dll;\
-mpir_gc_x64/mpir_gc.dll;\
-mpir_gc_x64/mpir_broadwell.dll;\
-mpir_gc_x64/mpir_broadwell_avx.dll;\
-mpir_gc_x64/mpir_bulldozer.dll;\
-mpir_gc_x64/mpir_haswell.dll;\
-mpir_gc_x64/mpir_piledriver.dll;\
-mpir_gc_x64/mpir_sandybridge.dll;\
-mpir_gc_x64/mpir_skylake_avx.dll \
+--add-dll mpir_gc_x64\mpir.dll;\
+mpir_gc_x64\mpir_gc.dll;\
+mpir_gc_x64\mpir_broadwell.dll;\
+mpir_gc_x64\mpir_broadwell_avx.dll;\
+mpir_gc_x64\mpir_bulldozer.dll;\
+mpir_gc_x64\mpir_haswell.dll;\
+mpir_gc_x64\mpir_piledriver.dll;\
+mpir_gc_x64\mpir_sandybridge.dll;\
+mpir_gc_x64\mpir_skylake_avx.dll \
 """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from setuptools import Command, Extension, setup, errors
 from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
-from looseversion import LooseVersion
 
 BUILD_HOOKS = []
 INSTALL_HOOKS = []
@@ -100,13 +99,6 @@ class CMakeBuild(build_ext):
                 + " the following extensions: "
                 + ", ".join(e.name for e in self.extensions)
             )
-
-        if platform.system() == "Windows":
-            cmake_version = LooseVersion(
-                re.search(r"version\s*([\d.]+)", out.decode()).group(1)
-            )
-            if cmake_version < "3.1.0":
-                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         for ext in self.extensions:
             self.build_extension(ext)

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ if BUILD_VDF_BENCH:
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(["cmake", "--version"])
+            subprocess.check_output(["cmake", "--version"])
         except OSError:
             raise RuntimeError(
                 "CMake must be installed to build"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ import re
 import shutil
 import subprocess
 import sys
-from distutils.command.install import install
-from distutils.version import LooseVersion
 
 from setuptools import Command, Extension, setup, errors
 from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
+from setuptools.command.install import install
+from looseversion import LooseVersion
 
 BUILD_HOOKS = []
 INSTALL_HOOKS = []

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import re
 import shutil
 import subprocess
 import sys


### PR DESCRIPTION
For increased simplicity, this PR removes the Cmake version check from setup.py. The minimum cmake version is set in the CMakeLists.txt
Also removes distutils from setup.py

Switches out the CNI-specific windows `delocate` for `delvewheel` which is the current method recommended by `cibuildwheel` for wheel repair on Windows. Appears to work but might need some additional testing on other CPU flavours to make sure the correct DLL is loaded.

- Tested on a Haswell CPU and the proper DLL was loaded (mpir_haswell.dll) 
- Confirmed all the other DLLs are present in the wheel package, so I hope this is working correctly