### PR TITLE
Fix uploads for releases of the c wrapper

### DIFF
--- a/.github/workflows/build-c-libraries.yml
+++ b/.github/workflows/build-c-libraries.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -126,6 +126,7 @@ jobs:
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'
+      shell: bash
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
On windows, need bash to make the syntax valid
For all, needed contents: write to be able to actually upload to the releases