### PR TITLE
Stop 1weso squaring

### DIFF
--- a/src/1weso_test.cpp
+++ b/src/1weso_test.cpp
@@ -49,7 +49,7 @@ int main(int argc, char const* argv[]) try
     uint64_t iter = iter_multiplier;
     OneWesolowskiCallback weso(D, f, iter);
     FastStorage* fast_storage = nullptr;
-    std::thread vdf_worker(repeated_square, f, D, L, &weso, fast_storage, std::ref(stopped));
+    std::thread vdf_worker(repeated_square, iter, f, D, L, &weso, fast_storage, std::ref(stopped));
     Proof const proof = ProveOneWesolowski(iter, D, f, &weso, stopped);
     stopped = true;
     vdf_worker.join();

--- a/src/2weso_test.cpp
+++ b/src/2weso_test.cpp
@@ -55,7 +55,7 @@ int main(int argc, char const* argv[]) try
     two_weso = true;
     TwoWesolowskiCallback weso(D, f);
     FastStorage* fast_storage = NULL;
-    std::thread vdf_worker(repeated_square, f, D, L, &weso, fast_storage, std::ref(stopped));
+    std::thread vdf_worker(repeated_square, 0, f, D, L, &weso, fast_storage, std::ref(stopped));
     // Test 1 - 1 million iters.
     uint64_t iteration = 1 * iter_multiplier;
     Proof proof = ProveTwoWeso(D, f, iteration, 0, &weso, 0, stopped);

--- a/src/prover_test.cpp
+++ b/src/prover_test.cpp
@@ -56,7 +56,7 @@ int main() {
     if (multi_proc_machine) {
         fast_storage = new FastStorage((FastAlgorithmCallback*)weso);
     }
-    std::thread vdf_worker(repeated_square, f, D, L, weso, fast_storage, std::ref(stopped));
+    std::thread vdf_worker(repeated_square, 0, f, D, L, weso, fast_storage, std::ref(stopped));
     ProverManager pm(D, (FastAlgorithmCallback*)weso, fast_storage, segments, thread_count);
     pm.start();
     std::vector<std::thread> threads;

--- a/src/vdf.h
+++ b/src/vdf.h
@@ -100,7 +100,7 @@ void repeated_square_original(vdf_original &vdfo, form& f, const integer& D, con
 }
 
 // thread safe; but it is only called from the main thread
-void repeated_square(form f, const integer& D, const integer& L,
+void repeated_square(uint64_t iterations, form f, const integer& D, const integer& L,
     WesolowskiCallback* weso, FastStorage* fast_storage, std::atomic<bool>& stopped)
 {
     #ifdef VDF_TEST
@@ -219,6 +219,11 @@ void repeated_square(form f, const integer& D, const integer& L,
             }
 
             last_checkpoint += (1 << 15);
+        }
+
+        if (iterations != 0 && num_iterations > iterations) {
+            weso->iterations = num_iterations;
+            break;
         }
 
         #ifdef VDF_TEST

--- a/src/vdf.h
+++ b/src/vdf.h
@@ -73,7 +73,7 @@ const int64_t EXP_THRESH = 31;
 // Notifies ProverManager class each time there's a new event.
 bool new_event = false;
 std::condition_variable new_event_cv;
-std::mutex new_event_mutex;
+std::mutex new_event_mutex, cout_lock;
 
 bool debug_mode = false;
 bool fast_algorithm = false;
@@ -237,7 +237,12 @@ void repeated_square(uint64_t iterations, form f, const integer& D, const intege
         #endif
     }
 
-    std::cout << "VDF loop finished. Total iters: " << num_iterations << "\n" << std::flush;
+    {
+        // this shouldn't be needed but avoids some false negatives in TSAN
+        std::lock_guard<std::mutex> lk(cout_lock);
+        std::cout << "VDF loop finished. Total iters: " << num_iterations << "\n";
+    }
+
     #ifdef VDF_TEST
         print( "fast average batch size", double(num_iterations_fast)/double(num_calls_fast) );
         print( "fast iterations per slow iteration", double(num_iterations_fast)/double(num_iterations_slow) );
@@ -271,7 +276,11 @@ Proof ProveOneWesolowski(uint64_t iters, integer& D, form f, OneWesolowskiCallba
     proof_serialized = SerializeForm(proof_form, d_bits);
     Proof proof(y_serialized, proof_serialized);
     proof.witness_type = 0;
-    std::cout << "Got simple weso proof: " << proof.hex() << "\n";
+    {
+        // this shouldn't be needed but avoids some false negatives in TSAN
+        std::lock_guard<std::mutex> lk(cout_lock);
+        std::cout << "Got simple weso proof: " << proof.hex() << "\n";
+    }
     return proof;
 }
 

--- a/src/vdf.h
+++ b/src/vdf.h
@@ -238,7 +238,7 @@ void repeated_square(uint64_t iterations, form f, const integer& D, const intege
     }
 
     {
-        // this shouldn't be needed but avoids some false negatives in TSAN
+        // this shouldn't be needed but avoids some false positives in TSAN
         std::lock_guard<std::mutex> lk(cout_lock);
         std::cout << "VDF loop finished. Total iters: " << num_iterations << "\n";
     }
@@ -277,7 +277,7 @@ Proof ProveOneWesolowski(uint64_t iters, integer& D, form f, OneWesolowskiCallba
     Proof proof(y_serialized, proof_serialized);
     proof.witness_type = 0;
     {
-        // this shouldn't be needed but avoids some false negatives in TSAN
+        // this shouldn't be needed but avoids some false positives in TSAN
         std::lock_guard<std::mutex> lk(cout_lock);
         std::cout << "Got simple weso proof: " << proof.hex() << "\n";
     }

--- a/src/vdf_client.cpp
+++ b/src/vdf_client.cpp
@@ -161,7 +161,7 @@ void SessionFastAlgorithm(tcp::socket& sock) {
             fast_storage = new FastStorage((FastAlgorithmCallback*)weso);
         }
         std::atomic<bool> stopped(false);
-        std::thread vdf_worker(repeated_square, f, std::ref(D), std::ref(L), weso, fast_storage, std::ref(stopped));
+        std::thread vdf_worker(repeated_square, 0, f, std::ref(D), std::ref(L), weso, fast_storage, std::ref(stopped));
         ProverManager pm(D, (FastAlgorithmCallback*)weso, fast_storage, segments, thread_count);
         pm.start();
 
@@ -211,7 +211,7 @@ void SessionOneWeso(tcp::socket& sock) {
         std::atomic<bool> stopped(false);
         WesolowskiCallback* weso = new OneWesolowskiCallback(D, f, iter);
         FastStorage* fast_storage = NULL;
-        std::thread vdf_worker(repeated_square, f, std::ref(D), std::ref(L), weso, fast_storage, std::ref(stopped));
+        std::thread vdf_worker(repeated_square, iter, f, std::ref(D), std::ref(L), weso, fast_storage, std::ref(stopped));
         std::thread th_prover(CreateAndWriteProofOneWeso, iter, std::ref(D), f, (OneWesolowskiCallback*)weso, std::ref(stopped), std::ref(sock));
         iter = ReadIteration(sock);
         while (iter != 0) {
@@ -247,7 +247,7 @@ void SessionTwoWeso(tcp::socket& sock) {
         std::set<std::pair<uint64_t, uint64_t> > seen_iterations;
         WesolowskiCallback* weso = new TwoWesolowskiCallback(D, f);
         FastStorage* fast_storage = NULL;
-        std::thread vdf_worker(repeated_square, f, std::ref(D), std::ref(L), weso, fast_storage, std::ref(stopped));
+        std::thread vdf_worker(repeated_square, 0, f, std::ref(D), std::ref(L), weso, fast_storage, std::ref(stopped));
 
         while (!stopped) {
             uint64_t iters = ReadIteration(sock);


### PR DESCRIPTION
For 1-Wesolowski proofs (used for "blueboxing") the squaring thread previously needlessly continued squaring while proof computation was in progress. In practice, proof computation also takes a while, so this could easily result in 10-20M additional squaring iterations. With this change, the squaring stops after the iterations target is reached. This also makes CPU utilisation more predictable. Previously, during squaring 2 threads were heavily utilised, and 3 threads during proof computation. Now it's never more than 2 high-load threads: 2 for squaring, 1 for proof computation.

This was originally written more than 2 years ago for the "blueboxing group" we ran in a SpaceFarmers.io Discord channel and was used by the people participating in that group intensively over several months. With the recently renewed interest in blueboxing, I remembered that I never got around to upstreaming that change: so here we go :)

see #174 