### PR TITLE
Change macos-latest to macos-12 for intel CPU

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-12, ubuntu-latest]
         config: [ optimized=1, TSAN=1, ASAN=1]
 
     steps:


### PR DESCRIPTION
The `macos-latest` tag was switched to Apple Silicon (arm) cpus, so use `macos-12` label to run the various tests on Intel CPU