### PR TITLE
Include stdbool.h in the c_wrapper/bindings. 

### DIFF
--- a/src/c_bindings/c_wrapper.h
+++ b/src/c_bindings/c_wrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 #include <cstddef> // for size_t


### PR DESCRIPTION
Go lint/vet tools (where I primary use these bindings) have gotten better and started complaining about this missing include

seems to only matter for versions older than c99, but doesn't hurt newer versions