### PR TITLE
Add _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR when building wheel on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,11 @@ if(BUILD_PYTHON)
   if(UNIX)
     target_link_libraries(chiavdf PRIVATE -pthread)
   endif()
+  if (WIN32)
+    # workaround for constexpr mutex constructor change in MSVC 2022
+    # https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio
+    target_compile_definitions(chiavdf PUBLIC _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+  endif()
 endif()
 
 add_executable(verifier_test


### PR DESCRIPTION
`chiavdf` may not have the same problem as `chiapos` - but this change seems like a good preventative measure just in case there is some future code that might cause issues

see `chiapos` PR https://github.com/Chia-Network/chiapos/pull/449

https://github.com/Chia-Network/chiapos/pull/449#issue-2517676917