### PR TITLE
Fix mpir on Rust binding

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,10 @@ jobs:
         run: cargo build --release
 
       - name: Prepare for publish
-        run: cp -r src rust_bindings/cpp
+        run: |
+          cd rust_bindings
+          cp -r ../src cpp
+          git clone https://github.com/Chia-Network/mpir_gc_x64.git
 
       - name: Publish to crates.io (dry run)
         # We use `--allow-dirty` because the `cpp` folder is copied into the working directory.


### PR DESCRIPTION
The MPIR library was not included in the crate, which means the binding could not be used on Windows.