### PR TITLE
xearl4's ApproximateParameter fix and GIL related parameter copies

### DIFF
--- a/src/callback.h
+++ b/src/callback.h
@@ -76,7 +76,7 @@ class OneWesolowskiCallback: public WesolowskiCallback {
         uint32_t k, l;
         this->wanted_iter = wanted_iter;
         if (wanted_iter >= (1 << 16)) {
-            ApproximateParameters(wanted_iter, k, l);
+            ApproximateParameters(wanted_iter, l, k);
         } else {
             k = 10;
             l = 1;

--- a/src/provers.h
+++ b/src/provers.h
@@ -11,7 +11,7 @@ class OneWesolowskiProver : public Prover {
     {
         this->intermediates = intermediates;
         if (num_iterations >= (1 << 16)) {
-            ApproximateParameters(num_iterations, k, l);
+            ApproximateParameters(num_iterations, l, k);
         } else {
             k = 10;
             l = 1;

--- a/src/python_bindings/fastvdf.cpp
+++ b/src/python_bindings/fastvdf.cpp
@@ -25,11 +25,14 @@ PYBIND11_MODULE(chiavdf, m) {
                                    const string& x_s, const string& y_s,
                                    const string& proof_s,
                                    uint64_t num_iterations) {
-        py::gil_scoped_release release;
         integer D(discriminant);
-        form x = DeserializeForm(D, (const uint8_t *)x_s.data(), x_s.size());
-        form y = DeserializeForm(D, (const uint8_t *)y_s.data(), y_s.size());
-        form proof = DeserializeForm(D, (const uint8_t *)proof_s.data(), proof_s.size());
+        std::string x_s_copy(x_s);
+        std::string y_s_copy(y_s);
+        std::string proof_s_copy(proof_s);
+        py::gil_scoped_release release;
+        form x = DeserializeForm(D, (const uint8_t *)x_s_copy.data(), x_s_copy.size());
+        form y = DeserializeForm(D, (const uint8_t *)y_s_copy.data(), y_s_copy.size());
+        form proof = DeserializeForm(D, (const uint8_t *)proof_s_copy.data(), proof_s_copy.size());
 
         bool is_valid = false;
         VerifyWesolowskiProof(D, x, y, proof, num_iterations, is_valid);
@@ -41,12 +44,14 @@ PYBIND11_MODULE(chiavdf, m) {
                                    const string& x_s,
                                    const string& proof_blob,
                                    const uint64_t num_iterations, const uint64_t disc_size_bits, const uint64_t recursion) {
+        std::string discriminant_copy(discriminant);
+        std::string x_s_copy(x_s);
+        std::string proof_blob_copy(proof_blob);
         py::gil_scoped_release release;
-        std::string proof_blob_str(proof_blob);
-        uint8_t *proof_blob_ptr = reinterpret_cast<uint8_t *>(proof_blob_str.data());
-        int proof_blob_size = proof_blob.size();
+        uint8_t *proof_blob_ptr = reinterpret_cast<uint8_t *>(proof_blob_copy.data());
+        int proof_blob_size = proof_blob_copy.size();
 
-        return CheckProofOfTimeNWesolowski(integer(discriminant), (const uint8_t *)x_s.data(), proof_blob_ptr, proof_blob_size, num_iterations, disc_size_bits, recursion);
+        return CheckProofOfTimeNWesolowski(integer(discriminant_copy), (const uint8_t *)x_s_copy.data(), proof_blob_ptr, proof_blob_size, num_iterations, disc_size_bits, recursion);
     });
 
     m.def("prove", [] (const py::bytes& challenge_hash, const string& x_s, int discriminant_size_bits, uint64_t num_iterations) {
@@ -75,11 +80,14 @@ PYBIND11_MODULE(chiavdf, m) {
                                    const uint64_t num_iterations, const uint64_t recursion) {
         std::pair<bool, std::vector<uint8_t>> result;
         {
+            std::string discriminant_copy(discriminant);
+            std::string B_copy(B);
+            std::string x_s_copy(x_s);
+            std::string proof_blob_copy(proof_blob);
             py::gil_scoped_release release;
-            std::string proof_blob_str(proof_blob);
-            uint8_t *proof_blob_ptr = reinterpret_cast<uint8_t *>(proof_blob_str.data());
-            int proof_blob_size = proof_blob.size();
-            result = CheckProofOfTimeNWesolowskiWithB(integer(discriminant), integer(B), (const uint8_t *)x_s.data(), proof_blob_ptr, proof_blob_size, num_iterations, recursion);
+            uint8_t *proof_blob_ptr = reinterpret_cast<uint8_t *>(proof_blob_copy.data());
+            int proof_blob_size = proof_blob_copy.size();
+            result = CheckProofOfTimeNWesolowskiWithB(integer(discriminant_copy), integer(B_copy), (const uint8_t *)x_s_copy.data(), proof_blob_ptr, proof_blob_size, num_iterations, recursion);
         }
         py::bytes res_bytes = py::bytes(reinterpret_cast<char*>(result.second.data()), result.second.size());
         py::tuple res_tuple = py::make_tuple(result.first, res_bytes);
@@ -90,11 +98,13 @@ PYBIND11_MODULE(chiavdf, m) {
                                    const string& x_s,
                                    const string& proof_blob,
                                    const uint64_t num_iterations, const uint64_t recursion) {
+        std::string discriminant_copy(discriminant);
+        std::string x_s_copy(x_s);
+        std::string proof_blob_copy(proof_blob);
         py::gil_scoped_release release;
-        std::string proof_blob_str(proof_blob);
-        uint8_t *proof_blob_ptr = reinterpret_cast<uint8_t *>(proof_blob_str.data());
-        int proof_blob_size = proof_blob.size();
-        integer B = GetBFromProof(integer(discriminant), (const uint8_t *)x_s.data(), proof_blob_ptr, proof_blob_size, num_iterations, recursion);
+        uint8_t *proof_blob_ptr = reinterpret_cast<uint8_t *>(proof_blob_copy.data());
+        int proof_blob_size = proof_blob_copy.size();
+        integer B = GetBFromProof(integer(discriminant_copy), (const uint8_t *)x_s_copy.data(), proof_blob_ptr, proof_blob_size, num_iterations, recursion);
         return B.to_string();
     });
 }

--- a/src/python_bindings/fastvdf.cpp
+++ b/src/python_bindings/fastvdf.cpp
@@ -51,6 +51,7 @@ PYBIND11_MODULE(chiavdf, m) {
 
     m.def("prove", [] (const py::bytes& challenge_hash, const string& x_s, int discriminant_size_bits, uint64_t num_iterations) {
         std::string challenge_hash_str(challenge_hash);
+        std::string x_s_copy(x_s);
         std::vector<uint8_t> result;
         {
             py::gil_scoped_release release;
@@ -59,7 +60,7 @@ PYBIND11_MODULE(chiavdf, m) {
                     challenge_hash_bytes,
                     discriminant_size_bits
             );
-            form x = DeserializeForm(D, (const uint8_t *) x_s.data(), x_s.size());
+            form x = DeserializeForm(D, (const uint8_t *) x_s_copy.data(), x_s_copy.size());
             result = ProveSlow(D, x, num_iterations);
         }
         py::bytes ret = py::bytes(reinterpret_cast<char*>(result.data()), result.size());


### PR DESCRIPTION
From xearl4:

The "fast" 1-Wesolowski prover inadvertently mixed up parameters in the call to ApproximateParameter.

ApproximateParameter's signature has L followed by K:

    void ApproximateParameters(uint64_t T, uint32_t& L, uint32_t& K)

However, the 1-Weso calls used K followed by L:

    ApproximateParameters(num_iterations, k, l);

While this typo does not affect the correctness of the created 1-Weso proof, this causes 1-Weso proving to be _much_ slower than necessary. In isolated testing, the 1-Weso proof generation is up to 10x slower.

Funnily enough, the "slow" VDF impl (in `src/provers_slow.h`) uses a separate 1-Weso prover implementation which _doesn't_ suffer from this bug, thus making the "slow" VDF impl faster than the "fast" overall.

To be clear: the fixed bug _only_ affects the _performance_ (not the correctness!) of computing 1-Weso proofs (thus, blueboxing) using the "fast" implementation. Regular software timelords (N-Weso), hardware (ASIC) timelords, and the "slow" bluebox implementation are unaffected.

The speedup can be observed/tested by running `src/1weso_test.cpp`:

    $ hyperfine --warmup 5 "./1weso_test.orig" "./1weso_test.fixed"
    Benchmark 1: ./1weso_test.orig
      Time (mean ± σ):     17.250 s ±  1.153 s    [User: 23.946 s, System: 0.037 s]
      Range (min … max):   15.582 s … 18.372 s    10 runs

    Benchmark 2: ./1weso_test.fixed
      Time (mean ± σ):      8.746 s ±  0.010 s    [User: 14.651 s, System: 0.029 s]
      Range (min … max):    8.733 s …  8.765 s    10 runs

    Summary
      ./1weso_test.fixed ran
        1.97 ± 0.13 times faster than ./1weso_test.orig

`1weso_test` also confirms that 1-Weso proof correctness is unaffected by this change. The prover still generates the exact same proofs, it just does so much faster.