### PR TITLE
Use generator for output directory

### DIFF
--- a/rust_bindings/build.rs
+++ b/rust_bindings/build.rs
@@ -28,23 +28,16 @@ fn main() {
 
     println!("cargo:rustc-link-lib=static=chiavdfc");
 
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("build")
+            .join("lib")
+            .join("static")
+            .to_str()
+            .unwrap()
+    );
+
     if cfg!(target_os = "windows") {
-        let build_type = if cfg!(debug_assertions) {
-            "Debug"
-        } else {
-            "Release"
-        };
-
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join("build")
-                .join("lib")
-                .join("static")
-                .join(build_type)
-                .to_str()
-                .unwrap()
-        );
-
         println!("cargo:rustc-link-lib=static=mpir");
         println!(
             "cargo:rustc-link-search=native={}",
@@ -56,15 +49,6 @@ fn main() {
                 .unwrap()
         );
     } else {
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join("build")
-                .join("lib")
-                .join("static")
-                .to_str()
-                .unwrap()
-        );
-
         println!("cargo:rustc-link-lib=gmp");
     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,12 +101,12 @@ if(BUILD_CHIAVDFC)
 
   set_target_properties(chiavdfc_shared PROPERTIES
           OUTPUT_NAME chiavdfc
-          LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/shared"
-          RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/shared"
+          LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib/shared>"
+          RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib/shared>"
   )
 
   set_target_properties(chiavdfc_static PROPERTIES
           OUTPUT_NAME chiavdfc
-          ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/static"
+          ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib/static>"
   )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,12 +101,12 @@ if(BUILD_CHIAVDFC)
 
   set_target_properties(chiavdfc_shared PROPERTIES
           OUTPUT_NAME chiavdfc
-          LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib/shared>"
-          RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib/shared>"
+          LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/shared$<0:>"
+          RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/shared$<0:>"
   )
 
   set_target_properties(chiavdfc_static PROPERTIES
           OUTPUT_NAME chiavdfc
-          ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib/static>"
+          ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/static$<0:>"
   )
 endif()


### PR DESCRIPTION
Using a "fake" generator for the directory makes the directory work in a simplified cross platform way. 

> Multi-configuration generators ([Visual Studio], [Xcode], [Ninja Multi-Config]) append a per-configuration subdirectory to the specified directory unless a generator expression is used
