### PR TITLE
Remove j2cli for jinjanator for jinja template rendering

### DIFF
--- a/.github/workflows/hw-build.yml
+++ b/.github/workflows/hw-build.yml
@@ -69,7 +69,7 @@ jobs:
           INSTALLER_VERSION: "${{ env.RELEASE_TAG || format('0.0.1-{0}', github.run_id) }}"
           PLATFORM: "amd64"
         run: |
-          pip install j2cli
+          pip install jinjanator
           CLI_DEB_BASE="chiavdf-hw_$INSTALLER_VERSION-1_$PLATFORM"
           mkdir -p "dist/$CLI_DEB_BASE/usr/bin"
           mkdir -p "dist/$CLI_DEB_BASE/usr/lib"


### PR DESCRIPTION
j2cli (which itself was a fork of jinja2-cli) was abandoned by the maintainers when python deprecated the imp package. jinjanator continued the cycle by forking j2cli and removing all the code that relied in imp so it works up to python 3.13