### PR TITLE
Use Og for debug compiling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ set(CMAKE_MODULE_PATH
 
 if(MSVC)
   add_compile_options(/EHsc)
+else()
+  add_compile_options("$<$<CONFIG:Debug>:-Og>")
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Per recommendation from Arvid, debug builds are useful with `-Og` as this allows some optimizations but only those that don't interfere with debugging. (Note Cmake will add in `-g` for us already)