### PR TITLE
Pin chiavdf-hw build workflow to ubuntu-22.04

### DIFF
--- a/.github/workflows/hw-build.yml
+++ b/.github/workflows/hw-build.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build-hw:
     name: Build HW VDF Client
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-22.04]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
To support older versions of glibc, and because ubuntu-latest recently began defaulting to 24.04.