### PR TITLE
remove boost_system

### DIFF
--- a/src/Makefile.vdf-client
+++ b/src/Makefile.vdf-client
@@ -7,7 +7,7 @@ NOPIE = -no-pie
 endif
 
 LDFLAGS += -flto $(NOPIE) -g
-LDLIBS += -lgmpxx -lgmp -lboost_system -pthread
+LDLIBS += -lgmpxx -lgmp -pthread
 CXXFLAGS += -flto -std=c++1z -D VDF_MODE=0 -D FAST_MACHINE=1 -pthread $(NOPIE) -fvisibility=hidden
 ifeq ($(UNAME),Darwin)
 CXXFLAGS += -D CHIAOSX=1


### PR DESCRIPTION
The latest version of boost has removed the boost_system library from its distribution, as it is no longer
necessary. 