### PR TITLE
Change fetch-depth to 0 in riscv64 workflow

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up QEMU on x86_64
         id: qemu


### PR DESCRIPTION
Adding this fix even though this workflow is currently disabled