### PR TITLE
Use GH naming for linux arm and simplify some non-matrix jobs

### DIFF
--- a/.github/workflows/build-c-libraries.yml
+++ b/.github/workflows/build-c-libraries.yml
@@ -30,17 +30,17 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              arm: [macos-15]
-              intel: [macos-15-intel]
+              arm: macos-15
+              intel: macos-15-intel
           - name: Ubuntu
             matrix: ubuntu
             runs-on:
               arm: ubuntu-24.04-arm
-              intel: [ubuntu-latest]
+              intel: ubuntu-latest
           - name: Windows
             matrix: windows
             runs-on:
-              intel: [windows-latest]
+              intel: windows-latest
         arch:
           - name: ARM
             matrix: arm
@@ -55,7 +55,7 @@ jobs:
               name: Windows
               matrix: windows
               runs-on:
-                intel: [windows-latest]
+                intel: windows-latest
             arch:
               name: ARM
               matrix: arm

--- a/.github/workflows/build-c-libraries.yml
+++ b/.github/workflows/build-c-libraries.yml
@@ -35,7 +35,7 @@ jobs:
           - name: Ubuntu
             matrix: ubuntu
             runs-on:
-              arm: [Linux, ARM64]
+              arm: ubuntu-24.04-arm
               intel: [ubuntu-latest]
           - name: Windows
             matrix: windows

--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -30,7 +30,7 @@ jobs:
           - name: Linux
             matrix: linux
             emoji: 🐧
-            runs-on: [ubuntu-latest]
+            runs-on: ubuntu-latest
         python:
           - major-dot-minor: '3.10'
             matrix: '3.10'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,20 +30,20 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              arm: [macos-15]
-              intel: [macos-15-intel]
+              arm: macos-15
+              intel: macos-15-intel
             cibw-archs-macos:
               arm: arm64
               intel: x86_64
           - name: Ubuntu
             matrix: ubuntu
             runs-on:
-              arm: [Linux, ARM64]
-              intel: [ubuntu-latest]
+              arm: ubuntu-24.04-arm
+              intel: ubuntu-latest
           - name: Windows
             matrix: windows
             runs-on:
-              intel: [windows-latest]
+              intel: windows-latest
         python:
           - major-dot-minor: '3.10'
             cibw-build: 'cp310-*'
@@ -84,7 +84,7 @@ jobs:
               name: Windows
               matrix: windows
               runs-on:
-                intel: [windows-latest]
+                intel: windows-latest
             arch:
               name: ARM
               matrix: arm
@@ -153,23 +153,8 @@ jobs:
         path: ./dist
 
   build-sdist:
-    name: sdist - ${{ matrix.os.name }} ${{ matrix.python.major-dot-minor }} ${{ matrix.arch.name }}
-    runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - name: Ubuntu
-            matrix: ubuntu
-            runs-on:
-              arm: [Linux, ARM64]
-              intel: [ubuntu-latest]
-        python:
-          - major-dot-minor: '3.12'
-            matrix: '3.12'
-        arch:
-          - name: Intel
-            matrix: intel
+    name: sdist - Ubuntu 3.12 Intel
+    runs-on: ubuntu-latest
 
     steps:
     - name: Clean workspace
@@ -182,7 +167,7 @@ jobs:
 
     - uses: Chia-Network/actions/setup-python@main
       with:
-        python-version: ${{ matrix.python.major-dot-minor }}
+        python-version: '3.12'
 
     - name: Build source distribution
       run: |
@@ -192,27 +177,12 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: packages-sdist-${{ matrix.os.name }}-${{ matrix.python.major-dot-minor }}-${{ matrix.arch.name }}
+        name: packages-sdist-Ubuntu-3.12-Intel
         path: ./dist
 
   check:
-    name: Check - ${{ matrix.os.name }} ${{ matrix.python.major-dot-minor }} ${{ matrix.arch.name }}
-    runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - name: Ubuntu
-            matrix: ubuntu
-            runs-on:
-              arm: [Linux, ARM64]
-              intel: [ubuntu-latest]
-        python:
-          - major-dot-minor: '3.12'
-            matrix: '3.12'
-        arch:
-          - name: Intel
-            matrix: intel
+    name: Check - Ubuntu 3.12 Intel
+    runs-on: ubuntu-latest
 
     steps:
     - name: Clean workspace
@@ -225,7 +195,7 @@ jobs:
 
     - uses: Chia-Network/actions/setup-python@main
       with:
-        python-version: ${{ matrix.python.major-dot-minor }}
+        python-version: '3.12'
 
     - name: flake8
       run: |
@@ -238,27 +208,12 @@ jobs:
         mypy --config-file mypi.ini setup.py tests
 
   upload:
-    name: Upload to PyPI - ${{ matrix.os.name }} ${{ matrix.python.major-dot-minor }} ${{ matrix.arch.name }}
-    runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
+    name: Upload to PyPI - Ubuntu 3.12 Intel
+    runs-on: ubuntu-latest
     needs:
       - build-wheels
       - build-sdist
       - check
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - name: Ubuntu
-            matrix: ubuntu
-            runs-on:
-              arm: [Linux, ARM64]
-              intel: [ubuntu-latest]
-        python:
-          - major-dot-minor: '3.12'
-            matrix: '3.12'
-        arch:
-          - name: Intel
-            matrix: intel
 
     steps:
     - name: Clean workspace
@@ -276,7 +231,7 @@ jobs:
 
     - uses: Chia-Network/actions/setup-python@main
       with:
-        python-version: ${{ matrix.python.major-dot-minor }}
+        python-version: '3.12'
 
     - name: Download artifacts
       uses: actions/download-artifact@v8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,7 +94,7 @@ jobs:
           - name: Ubuntu
             matrix: ubuntu
             runs-on:
-              arm: [Linux, ARM64]
+              arm: ubuntu-24.04-arm
               intel: [ubuntu-latest]
           - name: Windows
             matrix: windows

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,8 +86,8 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              arm: [macos-15]
-              intel: [macos-15-intel]
+              arm: macos-15
+              intel: macos-15-intel
             cibw-archs-macos:
               arm: arm64
               intel: x86_64
@@ -95,11 +95,11 @@ jobs:
             matrix: ubuntu
             runs-on:
               arm: ubuntu-24.04-arm
-              intel: [ubuntu-latest]
+              intel: ubuntu-latest
           - name: Windows
             matrix: windows
             runs-on:
-              intel: [windows-latest]
+              intel: windows-latest
 
         arch:
           - name: ARM
@@ -112,7 +112,7 @@ jobs:
               name: Windows
               matrix: windows
               runs-on:
-                intel: [windows-latest]
+                intel: windows-latest
             arch:
               name: ARM
               matrix: arm


### PR DESCRIPTION
Use `ubuntu-24.04-arm` for linux arm runners
Simplify jobs that didn't use the matrix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions runner selection and job matrices, which could break CI/release publishing if runner labels or artifact names no longer match expectations. Functional code is untouched, but build and upload automation is impacted.
> 
> **Overview**
> Updates GitHub Actions workflows to use GitHub’s explicit runner labels (not arrays), notably switching Linux ARM builds to `ubuntu-24.04-arm` across C library, wheel, and Rust test jobs.
> 
> Simplifies `build.yml`’s `build-sdist`, `check`, and `upload` jobs by removing their unused matrices and hardcoding Ubuntu/Python 3.12, including updating the corresponding artifact naming to fixed strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4aea9c413b87571b03013f2af86b7d4e839d7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->