### PR TITLE
Add PEP 561 type stubs for chiavdf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,15 +197,28 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libgmp-dev libgmpxx4ldbl
+
     - name: flake8
       run: |
         pip install flake8
-        flake8 tests setup.py
+        flake8 tests setup.py chiavdf
 
     - name: mypy
       run: |
         pip install mypy
-        mypy --config-file mypi.ini setup.py tests
+        mypy --config-file mypi.ini setup.py tests chiavdf
+
+    - name: stubtest
+      env:
+        BUILD_VDF_CLIENT: N
+      run: |
+        pip install mypy
+        pip install .
+        stubtest --concise chiavdf
 
   upload:
     name: Upload to PyPI - Ubuntu 3.12 Intel

--- a/chiavdf/__init__.py
+++ b/chiavdf/__init__.py
@@ -1,0 +1,21 @@
+from chiavdf._chiavdf import (
+    bqfc_deserialize,
+    create_discriminant,
+    create_discriminant_and_verify_n_wesolowski,
+    get_b_from_n_wesolowski,
+    prove,
+    verify_n_wesolowski,
+    verify_n_wesolowski_with_b,
+    verify_wesolowski,
+)
+
+__all__ = [
+    "bqfc_deserialize",
+    "create_discriminant",
+    "create_discriminant_and_verify_n_wesolowski",
+    "get_b_from_n_wesolowski",
+    "prove",
+    "verify_n_wesolowski",
+    "verify_n_wesolowski_with_b",
+    "verify_wesolowski",
+]

--- a/chiavdf/__init__.pyi
+++ b/chiavdf/__init__.pyi
@@ -1,0 +1,62 @@
+__all__ = [
+    "bqfc_deserialize",
+    "create_discriminant",
+    "create_discriminant_and_verify_n_wesolowski",
+    "get_b_from_n_wesolowski",
+    "prove",
+    "verify_n_wesolowski",
+    "verify_n_wesolowski_with_b",
+    "verify_wesolowski",
+]
+
+def create_discriminant(challenge_hash: bytes, discriminant_size_bits: int) -> str: ...
+def verify_wesolowski(
+    discriminant: str,
+    x_s: bytes | str,
+    y_s: bytes | str,
+    proof_s: bytes | str,
+    num_iterations: int,
+) -> bool: ...
+def verify_n_wesolowski(
+    discriminant: str,
+    x_s: bytes | str,
+    proof_blob: bytes,
+    num_iterations: int,
+    disc_size_bits: int,
+    recursion: int,
+) -> bool: ...
+def create_discriminant_and_verify_n_wesolowski(
+    challenge_hash: bytes,
+    discriminant_size_bits: int,
+    x_s: bytes | str,
+    proof_blob: bytes,
+    num_iterations: int,
+    recursion: int,
+) -> bool: ...
+def prove(
+    challenge_hash: bytes,
+    x_s: bytes | str,
+    discriminant_size_bits: int,
+    num_iterations: int,
+    shutdown_file_path: str,
+) -> bytes: ...
+def verify_n_wesolowski_with_b(
+    discriminant: str,
+    B: str,
+    x_s: bytes | str,
+    proof_blob: bytes,
+    num_iterations: int,
+    recursion: int,
+) -> tuple[bool, bytes]: ...
+def bqfc_deserialize(
+    discriminant: str,
+    data: bytes,
+    strict: bool = True,
+) -> tuple[bytes, bytes]: ...
+def get_b_from_n_wesolowski(
+    discriminant: str,
+    x_s: bytes | str,
+    proof_blob: bytes,
+    num_iterations: int,
+    recursion: int,
+) -> str: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
 test-requires = "pytest"
-test-command = "pytest -v {project}/tests"
+test-command = "mv {project}/chiavdf {project}/DO_NOT_IMPORT && pytest -v {project}/tests"
 skip = "cp31?t-* *-manylinux_i686 *-win32 *-musllinux_*"
 
 [tool.cibuildwheel.linux]

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,9 @@ setup(
     long_description=_long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Chia-Network/chiavdf",
-    ext_modules=[CMakeExtension("chiavdf", "src")],
+    packages=["chiavdf"],
+    package_data={"chiavdf": ["py.typed", "__init__.pyi"]},
+    ext_modules=[CMakeExtension("chiavdf._chiavdf", "src")],
     cmdclass=dict(build_ext=CMakeBuild, build_hook=build_hook),
     zip_safe=False,
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,19 +246,19 @@ if(BUILD_PYTHON)
     FetchContent_MakeAvailable(pybind11-src)
   endif()
 
-  pybind11_add_module(chiavdf
+  pybind11_add_module(_chiavdf
     ${CMAKE_CURRENT_SOURCE_DIR}/python_bindings/fastvdf.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/refcode/lzcnt.c
   )
 
-  target_link_libraries(chiavdf PRIVATE ${GMP_LIBRARIES} ${GMPXX_LIBRARIES})
+  target_link_libraries(_chiavdf PRIVATE ${GMP_LIBRARIES} ${GMPXX_LIBRARIES})
   if(UNIX)
-    target_link_libraries(chiavdf PRIVATE -pthread)
+    target_link_libraries(_chiavdf PRIVATE -pthread)
   endif()
   if (WIN32)
     # workaround for constexpr mutex constructor change in MSVC 2022
     # https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio
-    target_compile_definitions(chiavdf PUBLIC _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    target_compile_definitions(_chiavdf PUBLIC _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
   endif()
 endif()
 

--- a/src/python_bindings/fastvdf.cpp
+++ b/src/python_bindings/fastvdf.cpp
@@ -25,7 +25,7 @@ static py::bytes to_signed_bytes_be(const integer& value) {
     return py::bytes(out);
 }
 
-PYBIND11_MODULE(chiavdf, m) {
+PYBIND11_MODULE(_chiavdf, m) {
     m.doc() = "Chia proof of time";
 
     // Creates discriminant.


### PR DESCRIPTION
## Summary

- Package `chiavdf` as a proper PEP 561 module with `py.typed` and `__init__.pyi`
- Move the pybind11 extension to private `chiavdf._chiavdf` and re-export the public API from `chiavdf/__init__.py` (import path unchanged for callers)
- Add `stubtest` to the Ubuntu check job (build extension, then validate stubs against runtime)
- Avoid cibuildwheel importing the source tree during wheel tests by temporarily renaming `chiavdf/` (same pattern as other Chia native wheels)

## Test plan

- [x] CI `Check - Ubuntu 3.12 Intel` passes (flake8, mypy, stubtest)
- [x] CI cibuildwheel matrix passes on Linux/macOS/Windows
- [x] After release, bump chiavdf in chia-blockchain and remove `[mypy-chiavdf.*] ignore_missing_imports`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are packaging, typing, and CI only; VDF logic is unchanged aside from renaming the extension module, with stubtest intended to catch API mismatches.
> 
> **Overview**
> This PR makes **chiavdf** a PEP 561–typed package while keeping the public import path the same (`from chiavdf import …`).
> 
> The pybind11 extension is built as **`chiavdf._chiavdf`** instead of a top-level extension module; **`chiavdf/__init__.py`** re-exports the VDF API, and **`__init__.pyi`** plus **`py.typed`** document types for mypy and other checkers. **`setup.py`** / CMake / **`fastvdf.cpp`** are updated so the native target is **`_chiavdf`**.
> 
> CI on Ubuntu gains **cmake/GMP** install deps, extends **flake8** and **mypy** to the **`chiavdf`** package, and runs **`stubtest`** after **`pip install .`**. **cibuildwheel** temporarily renames the source **`chiavdf/`** tree during wheel tests so pytest uses the built wheel, not the checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdbc6d2dae91981b9b0db322a99fa32d8f3c07d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->