### PR TITLE
Fix Windows CI uint128 backend selection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,29 @@ endif()
 
 if(WIN32)
   add_compile_definitions(CHIA_WINDOWS NOMINMAX WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0601)
+
+  # Single source of truth for Windows 128-bit integer backend (see include.h).
+  set(CHIAVDF_USE_UINT128_T_FALLBACK 1)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("
+      int main() {
+        unsigned __int128 x = 0;
+        (void)x;
+        return 0;
+      }
+    " CHIAVDF_WINDOWS_NATIVE_UINT128)
+    if(CHIAVDF_WINDOWS_NATIVE_UINT128)
+      set(CHIAVDF_USE_UINT128_T_FALLBACK 0)
+    endif()
+  endif()
+  add_compile_definitions(CHIAVDF_USE_UINT128_T_FALLBACK=${CHIAVDF_USE_UINT128_T_FALLBACK})
+  if(CHIAVDF_USE_UINT128_T_FALLBACK)
+    message(STATUS "Windows 128-bit integers: uint128_t fallback")
+  else()
+    message(STATUS "Windows 128-bit integers: native unsigned __int128")
+  endif()
+
   set(MPIR_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../mpir_gc_x64")
   set(MPIR_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../mpir_gc_x64")
   include_directories(
@@ -129,9 +152,11 @@ set(VDF_COMMON_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/refcode/lzcnt.c
 )
 if(WIN32)
-  list(APPEND VDF_COMMON_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/uint128_t/uint128_t.cpp
-  )
+  if(CHIAVDF_USE_UINT128_T_FALLBACK)
+    list(APPEND VDF_COMMON_SOURCES
+      ${CMAKE_CURRENT_SOURCE_DIR}/uint128_t/uint128_t.cpp
+    )
+  endif()
 endif()
 
 set(VDF_ASM_SOURCES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ if(WIN32)
 
   # Single source of truth for Windows 128-bit integer backend (see include.h).
   set(CHIAVDF_USE_UINT128_T_FALLBACK 1)
+
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("
@@ -87,7 +88,9 @@ if(WIN32)
       set(CHIAVDF_USE_UINT128_T_FALLBACK 0)
     endif()
   endif()
+
   add_compile_definitions(CHIAVDF_USE_UINT128_T_FALLBACK=${CHIAVDF_USE_UINT128_T_FALLBACK})
+
   if(CHIAVDF_USE_UINT128_T_FALLBACK)
     message(STATUS "Windows 128-bit integers: uint128_t fallback")
   else()

--- a/src/Makefile.vdf-client
+++ b/src/Makefile.vdf-client
@@ -29,6 +29,7 @@ endif
 CFLAGS += $(LTO_FLAGS) $(NOPIE)
 LDFLAGS += $(LTO_FLAGS) $(NOPIE) -g
 ifeq ($(OS),Windows_NT)
+# 128-bit integer backend: CMake sets CHIAVDF_USE_UINT128_T_FALLBACK on Windows CI builds.
 LDLIBS += -lmpirxx -lmpir -lws2_32
 CXXFLAGS += $(LTO_FLAGS) -std=c++1z -D VDF_MODE=0 -D FAST_MACHINE=1 $(NOPIE) -fvisibility=hidden
 else

--- a/src/include.h
+++ b/src/include.h
@@ -26,11 +26,19 @@ typedef unsigned __int128 uint128;
 typedef __int128 int128;
 #define USED __attribute__((used))
 #else
-#if defined(__clang__) && defined(__SIZEOF_INT128__)
+// CHIAVDF_USE_UINT128_T_FALLBACK is set by CMake on Windows; Makefile builds infer a default below.
+#if !defined(CHIAVDF_USE_UINT128_T_FALLBACK)
+#  if defined(__clang__) && defined(__SIZEOF_INT128__)
+#    define CHIAVDF_USE_UINT128_T_FALLBACK 0
+#  else
+#    define CHIAVDF_USE_UINT128_T_FALLBACK 1
+#  endif
+#endif
+#if CHIAVDF_USE_UINT128_T_FALLBACK
+#  include "uint128_t/uint128_t.h"
+#else
 typedef unsigned __int128 uint128;
 typedef __int128 int128;
-#else
-#include "uint128_t/uint128_t.h"
 #endif
 #define USED
 #endif

--- a/src/include.h
+++ b/src/include.h
@@ -36,6 +36,7 @@ typedef __int128 int128;
 #endif
 #if CHIAVDF_USE_UINT128_T_FALLBACK
 #  include "uint128_t/uint128_t.h"
+typedef uint128_t uint128;
 #else
 typedef unsigned __int128 uint128;
 typedef __int128 int128;

--- a/src/uint128_t/uint128_t.include
+++ b/src/uint128_t/uint128_t.include
@@ -44,13 +44,6 @@ to do a general rewrite of this class.
 
 class UINT128_T_EXTERN uint128_t;
 
-// Give uint128_t type traits
-namespace std {  // This is probably not a good idea
-    template <> struct is_arithmetic <uint128_t> : std::true_type {};
-    template <> struct is_integral   <uint128_t> : std::true_type {};
-    template <> struct is_unsigned   <uint128_t> : std::true_type {};
-}
-
 class uint128_t{
     private:
         uint64_t UPPER, LOWER;


### PR DESCRIPTION
## Summary
- Remove illegal `namespace std` trait specializations from vendored `uint128_t` that break builds on MSVC STL 14.51 (`windows-latest`).
- Unify Windows 128-bit integer backend selection under `CHIAVDF_USE_UINT128_T_FALLBACK`, set by CMake and consumed by `include.h`.
- Skip compiling `uint128_t.cpp` on clang-cl CI when native `unsigned __int128` is available, and define `uint128` alias in the fallback path.

## Test plan
- [ ] Confirm `CI (windows-latest, optimized=1)` passes in VDF client & HW CI
- [ ] Verify Windows wheel builds still pass (MSVC fallback path)
- [ ] Confirm Linux/macOS CI unchanged


Made with [Cursor](https://cursor.com)