### PR TITLE
Require Python >=3.10 to match chia-blockchain

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     author_email="florin@chia.net",
     description="Chia vdf verification (wraps C++)",
     license="Apache-2.0",
-    python_requires=">=3.9",
+    python_requires=">=3.10, <4",
     long_description=_long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Chia-Network/chiavdf",


### PR DESCRIPTION
## Summary
- Raise `python_requires` from `>=3.9` to `>=3.10, <4`, matching `chia-blockchain` and `chiapos`.
- Wheel CI already builds/tests 3.10–3.14; this aligns package metadata with that support range.

## Test plan
- [ ] Confirm CI wheel matrix still covers 3.10–3.14
- [ ] Confirm package metadata reports `Requires-Python: >=3.10, <4`


Made with [Cursor](https://cursor.com)