### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'))
+    if: github.repository_owner == 'Chia-Network' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -766,7 +766,6 @@ jobs:
           fi
 
       - name: Run Cursor analysis
-        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow gating with no application, auth, or data-path changes.
> 
> **Overview**
> Restricts the **Dependency Cursor Review** workflow so the whole `dependency-review` job runs only when `github.repository_owner == 'Chia-Network'`, in addition to the existing Dependabot/Renovate and dispatch/PR triggers.
> 
> The per-step `if: github.repository_owner == 'Chia-Network'` on **Run Cursor analysis** is removed because the job-level guard already covers that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 888a231ba9cd8c4cced5c2dc777326fecebcf5c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->