### PR TITLE
Gate test-only code with VDF_TEST

### DIFF
--- a/src/vdf.h
+++ b/src/vdf.h
@@ -19,9 +19,6 @@
 #include "vdf_new.h"
 #include "picosha2.h"
 
-#include "gpu_integer.h"
-#include "gpu_integer_divide.h"
-
 #include "nucomp.h"
 
 #include "nudupl_listener.h"
@@ -32,7 +29,6 @@
 #include "gcd_base_continued_fractions.h"
 //#include "gcd_base_divide_table.h"
 #include "gcd_128.h"
-#include "gcd_unsigned.h"
 
 #include "asm_types.h"
 
@@ -41,11 +37,18 @@
 #include "vdf_fast.h"
 #endif
 
+// Reference / correctness-test integer path (fixed_integer). Not used by the
+// production ASM squaring pipeline; keep it out of VDF_MODE=0 builds.
+#ifdef VDF_TEST
+#include "gpu_integer.h"
+#include "gpu_integer_divide.h"
+#include "gcd_unsigned.h"
 #include "gpu_integer_gcd.h"
-
 #if (defined(ARCH_X86) || defined(ARCH_X64)) && !defined(CHIA_DISABLE_ASM)
 #include "vdf_test.h"
 #endif
+#endif
+
 #include <map>
 #include <algorithm>
 #include <chrono>


### PR DESCRIPTION
## Summary
- Gate `gpu_integer*`, template `gcd_unsigned.h`, and `vdf_test.h` includes in `vdf.h` behind `#ifdef VDF_TEST` so production `VDF_MODE=0` builds (e.g. `vdf_client`) no longer compile the unused `fixed_integer` reference path.
- Leaves the production ASM squaring pipeline (`threading.h` / `vdf_fast.h`) unchanged. The reference path remains available when `VDF_MODE=1` (which defines `VDF_TEST`).

Addresses assert-only overflow hygiene in `fixed_integer(const integer&)`: that constructor is not on the production verify/`prove` path and is no longer linked into production `vdf_client`.

## Test plan
- [x] `cmake -S src -B build-vdf-test-gate -DBUILD_PYTHON=OFF -DBUILD_CHIAVDFC=OFF -DBUILD_VDF_CLIENT=ON -DBUILD_VDF_BENCH=OFF -DBUILD_VDF_TESTS=ON -DBUILD_HW_TOOLS=OFF`
- [x] `cmake --build build-vdf-test-gate --target vdf_client regression_unit_tests 1weso_test 2weso_test prover_test`
- [x] `ctest --test-dir build-vdf-test-gate --output-on-failure -R '^regression\.'` (19/19 passed)
- [x] Confirmed no `fixed_integer` / `square_fast_impl` symbols in built `vdf_client`


Made with [Cursor](https://cursor.com)