### PR TITLE
Update pybind11 requirement from >=3.0.4 to >=3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=84.0.0", "wheel", "setuptools_scm[toml]>=10.2.1", "pybind11>=3.0.4"]
+requires = ["setuptools>=84.0.0", "wheel", "setuptools_scm[toml]>=10.2.1", "pybind11>=3.1.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -269,7 +269,7 @@ if(BUILD_PYTHON)
     FetchContent_Declare(
       pybind11-src
       GIT_REPOSITORY https://github.com/pybind/pybind11.git
-      GIT_TAG        v3.0.4
+      GIT_TAG        v3.1.0
     )
     FetchContent_MakeAvailable(pybind11-src)
   endif()


### PR DESCRIPTION
Supersedes #400.

Updates the pybind11 build-system requirement from `>=3.0.4` to `>=3.1.0` in `pyproject.toml` (from dependabot), **and** bumps the CMake `FetchContent` fallback `GIT_TAG` from `v3.0.4` to `v3.1.0` in `src/CMakeLists.txt`.

This addresses the [Cursor Bugbot finding](https://github.com/Chia-Network/chiavdf/pull/400#pullrequestreview-2963759987) on #400 — the `FetchContent` fallback was still pinned to `v3.0.4`, meaning pip-isolated builds and fallback CMake builds could diverge.

**Changes:**
- `pyproject.toml`: `pybind11>=3.0.4` → `pybind11>=3.1.0` (from dependabot)
- `src/CMakeLists.txt`: `GIT_TAG v3.0.4` → `GIT_TAG v3.1.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version alignment for Python bindings only; no application logic or security-sensitive code changes.
> 
> **Overview**
> Bumps the **pybind11** dependency from **3.0.4** to **3.1.0** in two places so they stay in sync: the PEP 517 build requirement in `pyproject.toml` and the CMake `FetchContent` `GIT_TAG` in `src/CMakeLists.txt` used when `find_package(pybind11)` does not find an installed copy.
> 
> Normal wheel builds still prefer pybind11 from the active Python environment via `python -m pybind11 --cmakedir`; only isolated or fallback CMake paths rely on the pinned tag, which previously could still pull **v3.0.4** while pip required **>=3.1.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbe5c2604fda67a7e4dae3becb12ff5993b11f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->